### PR TITLE
Launcher3: Add ACCESS_SURFACE_FLINGER permission to manifest

### DIFF
--- a/AndroidManifest-common.xml
+++ b/AndroidManifest-common.xml
@@ -47,6 +47,7 @@
     <uses-permission android:name="android.permission.SUSPEND_APPS" />
     <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" />
     <!-- for rotating surface by arbitrary degree -->
+    <uses-permission android:name="android.permission.ACCESS_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.ROTATE_SURFACE_FLINGER" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_HOME_APP_SEARCH_DATA" />


### PR DESCRIPTION
Fixes
06-21 09:27:41.679   447   986 E SurfaceFlinger: Only WindowManager is allowed to use eEarlyWakeup[Start|End] flags

Change-Id: I9e68b318faafac4a2b34d73c703cf98168c2a32d